### PR TITLE
New middle name, or: Wer A(nanasbeet) sagt muss auch P(flanz) sagen

### DIFF
--- a/content.js
+++ b/content.js
@@ -81,6 +81,7 @@ const substitutionsMiddle = [
     'Lanz',
     'Mampf',
     'Pfand',
+    'Pflanz',
     'Punk',
     'Sand',
     'Schrank',


### PR DESCRIPTION
This PR adds "Pflanz" to the list of "middle" names to enable this plugin to generate the objectively perfect name "Ananasbeet Pflanz-Gartenlaube".

It also fits "Karottenbauer" quite well.