### PR TITLE
Tweak regex to match name with missing hyphen

### DIFF
--- a/content.js
+++ b/content.js
@@ -158,7 +158,7 @@ const getRandomEntry = entries => entries[Math.floor(Math.random() * entries.len
 
 const pageHtml = document.getElementsByTagName('html')[0].innerHTML;
 
-const regexName = /(?:Annegret )?Kramp-Karrenbauer/gi;
+const regexName = /(?:Annegret )?Kramp[ -]Karrenbauer/gi;
 const regexShort = /\bAKK\b(?![ -]47)/gi;
 
 if (pageHtml.match(regexName) || pageHtml.match(regexShort)) {


### PR DESCRIPTION
This PR tweaks the full name regex to allow a single space in place of the hyphen between the two surnames of Krank-Knarrenbauer.

It's a common mistake to forget about proper hyphenation, so this change catches that.

As a side effect, this actually *fixes* the hyphenation on websites that get it wrong. I guess it could be discussed if this is a bug or a feature. In case we want to leave the incorrect hyphenation intact we'd have to add a capture group around `[ -]` and then add the captured character in [line 172](https://github.com/voodoocode/pannengeraet-krank-knarrenbauer/compare/master...catearcher:patch-2#R172). I'd advise against that, though. I like it if punctuation gets fixed.