### PR TITLE
Add Bernd Höcke

### DIFF
--- a/people.js
+++ b/people.js
@@ -216,4 +216,12 @@ const people = [
     substitutionsLast: ["Merkel"],
     substitutionsComplete: ["Mutti"],
   },
+  {
+    regexName: /(?:Björn )?Höcke/gi,
+    regexAbbrev: null,
+    substitutionsFirst: ["Bernd"],
+    substitutionsMiddle: [" "],
+    substitutionsLast: ["Höcke"],
+    substitutionsComplete: ["AfD-Onkel"],
+  },
 ];


### PR DESCRIPTION
Björn Höcke (AfD) is now Bernd Höcke.
This is a well-known joke created by the "Heute Show".
Sources:
https://www.shz.de/deutschland-welt/politik/bjoern-oder-bernd-hoecke-wie-heisst-der-afd-onkel-wirklich-id16452451.html
https://www.stern.de/kultur/tv/bernd-statt-bjoern--so-feiert-die--heute-show--die-hoecke-panne-des-bundestags-7839714.html